### PR TITLE
Tt 7922 cent string edge cases fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change Log
-All notable changes to this project will be documented in this file.  
-This project adheres to [Semantic Versioning](http://semver.org/).  
-This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).  
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
+
+## 1.4.0 Unreleased
+
+- [TT-7922] Fixed some edge cases when initialising from string values
 
 ## 1.3.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2320,6 +2320,11 @@
         }
       }
     },
+    "currency.js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/currency.js/-/currency.js-2.0.3.tgz",
+      "integrity": "sha512-3rtzulRMwUJHmH0EPKiO/taYEGWlLSG2rpBOaHhfaY1dPGqK595mjg4t4bksy7glHEPZry7l5xSpXECs1eFrWg=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "url": "https://github.com/sealink/money_beans/issues"
   },
   "homepage": "https://github.com/sealink/money_beans#readme",
+  "dependencies": {
+    "currency.js": "2.0.3"
+  },
   "devDependencies": {
     "@babel/core": "^7.7.7",
     "@babel/preset-env": "^7.7.7",

--- a/src/money.js
+++ b/src/money.js
@@ -13,8 +13,7 @@ export default class Money {
   }
 
   static buildFromString(stringNumber) {
-    const currencyValue = currency(stringNumber)
-    return currencyValue.dollars() * 100 + currencyValue.cents();
+    return currency(stringNumber).value * 100;
   }
 
   static format(amount) {

--- a/src/money.js
+++ b/src/money.js
@@ -13,11 +13,17 @@ export default class Money {
   static buildFromString(stringNumber) {
     // remove everything (comma, $, etc.) except the number and decimal in between
     // - decimal optional, no decimal = dollars
-    const number = stringNumber.replace(/,/g, "").match(/[0-9]+.?[0-9]*/, "");
+    const number = stringNumber.replace(/,/g, "").match(/[0-9]*\.?[0-9]*$/, "");
     if (number == null) return 0; // if num is other string
     const numbers = number[0].split(".");
-    const dollars = parseInt(numbers[0], 0);
-    const cents = numbers[1] != null ? parseInt(numbers[1], 0) : 0;
+    const dollars = parseInt(numbers[0], 10) || 0;
+    var centString = numbers[1];
+    // padding centString if it's only a single digit
+    // so that .2 is counted as 20 cents instead of 2
+    if (centString?.length == 1) {
+      centString = `${centString}0`;
+    }
+    const cents = centString != null ? parseInt(centString, 10) : 0;
     return dollars * 100 + cents;
   }
 

--- a/src/money.js
+++ b/src/money.js
@@ -17,9 +17,10 @@ export default class Money {
     if (number == null) return 0; // if num is other string
     const numbers = number[0].split(".");
     const dollars = parseInt(numbers[0], 10) || 0;
-    var centString = numbers[1];
+    var centString = numbers[1]?.substring(0, 2);
     // padding centString if it's only a single digit
     // so that .2 is counted as 20 cents instead of 2
+    // Also truncates anything past 2 decimal places (no rounding, only truncating)
     if (centString?.length == 1) {
       centString = `${centString}0`;
     }

--- a/src/money.js
+++ b/src/money.js
@@ -1,3 +1,5 @@
+import currency from "currency.js";
+
 export default class Money {
   constructor(num) {
     this.cents = Money.getCents(num);
@@ -11,21 +13,8 @@ export default class Money {
   }
 
   static buildFromString(stringNumber) {
-    // remove everything (comma, $, etc.) except the number and decimal in between
-    // - decimal optional, no decimal = dollars
-    const number = stringNumber.replace(/,/g, "").match(/[0-9]*\.?[0-9]*$/, "");
-    if (number == null) return 0; // if num is other string
-    const numbers = number[0].split(".");
-    const dollars = parseInt(numbers[0], 10) || 0;
-    var centString = numbers[1]?.substring(0, 2);
-    // padding centString if it's only a single digit
-    // so that .2 is counted as 20 cents instead of 2
-    // Also truncates anything past 2 decimal places (no rounding, only truncating)
-    if (centString?.length == 1) {
-      centString = `${centString}0`;
-    }
-    const cents = centString != null ? parseInt(centString, 10) : 0;
-    return dollars * 100 + cents;
+    const currencyValue = currency(stringNumber)
+    return currencyValue.dollars() * 100 + currencyValue.cents();
   }
 
   static format(amount) {

--- a/test/money_test.js
+++ b/test/money_test.js
@@ -33,6 +33,12 @@ describe("Money", function() {
       expect(money.cents).to.be(120);
     })
 
+    it("returns correct money string value", function() {
+      const moneyString = "1.200";
+      const money = new Money(moneyString);
+      expect(money.cents).to.be(120);
+    })
+
     it("returns correct money from invalid string value", function() {
       const money = new Money("abc");
       expect(money.cents).to.be(0);

--- a/test/money_test.js
+++ b/test/money_test.js
@@ -21,6 +21,18 @@ describe("Money", function() {
       expect(money.cents).to.be(100);
     });
 
+    it("returns correct money string value", function() {
+      const moneyString = ".2";
+      const money = new Money(moneyString);
+      expect(money.cents).to.be(20);
+    })
+
+    it("returns correct money string value", function() {
+      const moneyString = "1.2";
+      const money = new Money(moneyString);
+      expect(money.cents).to.be(120);
+    })
+
     it("returns correct money from invalid string value", function() {
       const money = new Money("abc");
       expect(money.cents).to.be(0);


### PR DESCRIPTION
Fixed up `buildFromString` as it wasn't handling some edge cases correctly.

Values starting with a period (.) will now be correctly interpreted as cent values. Previously the regex was ignoring the period and counted them as dollar values.
Cent values with a single digit are now multiplied by ten, so a value of `1.2` was previously interpreted as `$1.02`, will now be interpreted as `$1.20`.