### PR TITLE
Tt 8018 value of method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
+## Unreleased
+
+- [TT-8018] Add valueOf method for backwards compatibility with v1.2.0
+
 ## 1.4.1
 
 - [TT-7968] Using currency.js intValue for greater accuracy

--- a/src/money.js
+++ b/src/money.js
@@ -92,6 +92,10 @@ export default class Money {
     return this.format();
   }
 
+  valueOf() {
+    return this.dollars().toFixed(2);
+  }
+
   round() {
     const modulo = this.cents % 5;
 

--- a/test/money_test.js
+++ b/test/money_test.js
@@ -183,6 +183,39 @@ describe("Money", function() {
     });
   });
 
+  describe("coercion", function() {
+    // Large is determined by when the "," seperator gets applied which is currently at 1000
+    it("has correct primitive value for large positive fractionals", function() {
+      const money = new Money("$1000.50");
+      expect(Math.abs(money)).to.be(1000.50);
+    });
+
+    it("has correct primitive value for large negative fractionals", function() {
+      const money = new Money("$-1000.50");
+      expect(Math.abs(money)).to.be(1000.50);
+    });
+
+    it("has correct primitive value for large whole numbers", function() {
+      const money = new Money("$1000");
+      expect(Math.abs(money)).to.be(1000);
+    });
+
+    it("has correct primitive value for large negative whole numbers", function() {
+      const money = new Money("$-1000");
+      expect(Math.abs(money)).to.be(1000);
+    });
+
+    it("has correct primitive value for small whole numbers", function() {
+      const money = new Money("$1");
+      expect(Math.abs(money)).to.be(1);
+    });
+
+    it("has correct primitive value for small fractional numbers", function() {
+      const money = new Money("$1.5");
+      expect(Math.abs(money)).to.be(1.50);
+    });
+  });
+
   describe("rounding", function() {
     describe("positive numbers", function() {
       it("rounds down", function() {


### PR DESCRIPTION
### WHY

The change in 1.2 to introduce "," separators in the default toString implementation also broke compatibliity with previous version for example when passing the money object directly to Math.abs

### TEST

Test suite is updated