### PR TITLE
[TF-901] Fix can not find module issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- [TF-901] Fix can not find module issue
+
 ## 1.8.1
 
 - [PLAT-1203] Release with Node 18, no longer install npm@7 during build

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.8.1",
   "description": "Create JS money objects from strings, integers or floats",
   "main": "./dist/money.js",
+  "module": "./dist/money.esm.js",
   "scripts": {
     "prebuild": "eslint src",
     "build": "rollup -c --environment BUILD:production",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@sealink/money_beans",
   "version": "1.8.1",
   "description": "Create JS money objects from strings, integers or floats",
+  "main": "./dist/money.js",
   "scripts": {
     "prebuild": "eslint src",
     "build": "rollup -c --environment BUILD:production",


### PR DESCRIPTION
## WHY

After upgrade `@sealink/money_beans` from `1.6.0` to `1.8.1`, I got `Cannot find module '@sealink/money_beans' from xxx` error.

## WHAT

The `main` field was removed from https://github.com/sealink/money_beans/pull/634/files, add it back can solve the issue

## TEST

QT jest test pass